### PR TITLE
Custom variable rules in Logseq

### DIFF
--- a/src/main/frontend/extensions/sci.cljs
+++ b/src/main/frontend/extensions/sci.cljs
@@ -17,6 +17,31 @@
 (defn- average [coll]
   (/ (reduce + coll) (count coll)))
 
+(defn week-number
+  "Week number according to the ISO-8601 standard, weeks starting on
+  Monday. The first week of the year is the week that contains that
+  year's first Thursday (='First 4-day week'). The highest week number
+  in a year is either 52 or 53."
+  []
+  (let [year (.getFullYear (js/Date.))
+        month (.getMonth (js/Date.))
+        date (.getDate (js/Date.))
+        day (.getDay (js/Date.))
+        thursday (js/Date. year month (- (+ date 4) (if (= 0 day) 7 day)))
+        year-start (js/Date. year 0 1)]
+    (Math/ceil (/ (+ (/ (- (.getTime thursday)
+                           (.getTime year-start))
+                        (* 1000 60 60 24))
+                     1)
+                  7))))
+
+(defn week-year
+  []
+  (let [date (js/Date.)]
+  (.setDate date (- (+ (.getDate date) 3)
+                   (mod (+ 6 (.getDay date)) 7)))
+  (.getFullYear date)))
+
 (defn- call-api
   "Given a fn name from logseq.api, invokes it with the given arguments"
   [fn-name & args]
@@ -35,6 +60,8 @@
      (sci/eval-string s (merge-with merge
                                     {:bindings {'sum sum
                                                 'average average
+                                                'week-number week-number
+                                                'week-year week-year
                                                 'parseFloat js/parseFloat
                                                 'isNaN js/isNaN
                                                 'log js/console.log

--- a/src/main/frontend/schema/handler/common_config.cljc
+++ b/src/main/frontend/schema/handler/common_config.cljc
@@ -13,9 +13,7 @@
     [:default-templates [:map-of
                          [:enum :journals]
                          :string]]
-    [:variable-rules [:map-of
-                      :string
-                      :string]]
+    [:variable-rules [:vector :map]]
     [:ui/enable-tooltip? :boolean]
     [:ui/show-brackets? :boolean]
     [:feature/enable-block-timestamps? :boolean]

--- a/src/main/frontend/schema/handler/common_config.cljc
+++ b/src/main/frontend/schema/handler/common_config.cljc
@@ -13,9 +13,9 @@
     [:default-templates [:map-of
                          [:enum :journals]
                          :string]]
-    [::variable-rules [:map-of
-                        :string
-                        :string]]
+    [:variable-rules [:map-of
+                      :string
+                      :string]]
     [:ui/enable-tooltip? :boolean]
     [:ui/show-brackets? :boolean]
     [:feature/enable-block-timestamps? :boolean]

--- a/src/main/frontend/schema/handler/common_config.cljc
+++ b/src/main/frontend/schema/handler/common_config.cljc
@@ -13,6 +13,9 @@
     [:default-templates [:map-of
                          [:enum :journals]
                          :string]]
+    [::variable-rules [:map-of
+                        :string
+                        :string]]
     [:ui/enable-tooltip? :boolean]
     [:ui/show-brackets? :boolean]
     [:feature/enable-block-timestamps? :boolean]

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -395,6 +395,11 @@ should be done through this fn in order to get global config and config defaults
     (when-not (string/blank? template)
       (string/trim template))))
 
+(defn get-variable-rules
+  []
+  (when-let [rules (get-in (get-config) [:variable-rules])]
+    rules))
+
 (defn all-pages-public?
   []
   (let [value (:publishing/all-pages-public? (get-config))

--- a/src/main/frontend/state.cljs
+++ b/src/main/frontend/state.cljs
@@ -5,6 +5,7 @@
             [cljs.core.async :as async :refer [<!]]
             [cljs.spec.alpha :as s]
             [clojure.string :as string]
+            [frontend.extensions.sci :as sci]
             [dommy.core :as dom]
             [electron.ipc :as ipc]
             [frontend.mobile.util :as mobile-util]
@@ -397,8 +398,11 @@ should be done through this fn in order to get global config and config defaults
 
 (defn get-variable-rules
   []
-  (when-let [rules (get-in (get-config) [:variable-rules])]
-    rules))
+  (when-let [rule (get-in (get-config) [:variable-rules])]
+    (into {} (map (fn [rule]
+                    (if (:is-code? rule)
+                      (hash-map (:rule rule) (sci/eval-string (:value rule)))
+                      (hash-map (:rule rule) (:value rule)))) rule))))
 
 (defn all-pages-public?
   []

--- a/src/main/frontend/template.cljs
+++ b/src/main/frontend/template.cljs
@@ -7,12 +7,12 @@
 
 (defn- variable-rules
   []
-  {"today" (page-ref/->page-ref (date/today))
-   "yesterday" (page-ref/->page-ref (date/yesterday))
-   "tomorrow" (page-ref/->page-ref (date/tomorrow))
-   "time" (date/get-current-time)
-   "current page" (page-ref/->page-ref (or (state/get-current-page)
-                                           (date/today)))})
+  (merge {"today" (page-ref/->page-ref (date/today))
+          "yesterday" (page-ref/->page-ref (date/yesterday))
+          "tomorrow" (page-ref/->page-ref (date/tomorrow))
+          "time" (date/get-current-time)
+          "current page" (page-ref/->page-ref (or (state/get-current-page)
+                                              (date/today)))} (state/get-variable-rules)))
 
 ;; TODO: programmable
 ;; context information, date, current page

--- a/templates/config.edn
+++ b/templates/config.edn
@@ -81,7 +81,7 @@
  ;; If `:sidebar` is not set, sidebar will be hidden
  ;; Example:
  ;; 1. Setup page "Changelog" as home page and "Contents" in sidebar
-;;  :default-home {:page "Changelog", :sidebar "Contents"}
+ ;; :default-home {:page "Changelog", :sidebar "Contents"}
  ;; 2. Setup page "Jun 3rd, 2021" as home page without sidebar
  ;; :default-home {:page "Jun 3rd, 2021"}
  ;; 3. Setup page "home" as home page with multiple pages in sidebar

--- a/templates/config.edn
+++ b/templates/config.edn
@@ -20,8 +20,10 @@
  :default-templates
  {:journals ""}
 
+
+;; E.g.  [{:rule "name" :value "value" :is-code? false} {:rule "weekday" :value "(+ 1 1)" :is-code? true}]
  :variable-rules 
- {}
+ []
 
  ;; Whether to enable hover on tooltip preview feature
  ;; Default is true, you can also toggle this via setting page

--- a/templates/config.edn
+++ b/templates/config.edn
@@ -20,6 +20,9 @@
  :default-templates
  {:journals ""}
 
+ :variable-rules 
+ {}
+
  ;; Whether to enable hover on tooltip preview feature
  ;; Default is true, you can also toggle this via setting page
  :ui/enable-tooltip? true
@@ -78,7 +81,7 @@
  ;; If `:sidebar` is not set, sidebar will be hidden
  ;; Example:
  ;; 1. Setup page "Changelog" as home page and "Contents" in sidebar
- ;; :default-home {:page "Changelog", :sidebar "Contents"}
+;;  :default-home {:page "Changelog", :sidebar "Contents"}
  ;; 2. Setup page "Jun 3rd, 2021" as home page without sidebar
  ;; :default-home {:page "Jun 3rd, 2021"}
  ;; 3. Setup page "home" as home page with multiple pages in sidebar


### PR DESCRIPTION
- [X] custom variable defined in config.edn. Can be use in Logseq as `<% variable %>`
- [X] value of custom variable can be specify as Clojure code and will be evaluate when the variable is being used